### PR TITLE
Support for tab character as a field delimiter.

### DIFF
--- a/src/parsecmd.cpp
+++ b/src/parsecmd.cpp
@@ -127,7 +127,7 @@ int parsecmd_getopts(	opts_t &opts,
 	csv_set_default_values(opts);
 	xls_set_default_values(opts);
 	int opt;
-	while ((opt = getopt(argc, argv, "b:d:hHl:o:w:D:v")) != -1)
+	while ((opt = getopt(argc, argv, "b:d:thHl:o:w:D:v")) != -1)
 	{
 		stringstream ss;
 
@@ -139,6 +139,9 @@ int parsecmd_getopts(	opts_t &opts,
 			break;
 		case 'd':
 			opts.csv_tab_delimiter = optarg[0];
+			break;
+		case 't':
+			opts.csv_tab_delimiter = 9; // tab character as a delimiter
 			break;
 		case 'H':
 			opts.csv_file_has_headline = true;

--- a/src/print_help.cpp
+++ b/src/print_help.cpp
@@ -30,6 +30,9 @@ void print_help(char*executable)
 			<< (char) DEFAULT_CSV_TAB_DELIMITER << "\'" << std::endl
 			<< std::endl;
 
+	std::cout << "-t" << "\tset csv tab delimiter to tab character (ASCII 9)."
+			<< std::endl;
+
 	std::cout << "-h" << "\tPrint this help text and exit." << std::endl
 			<< std::endl;
 


### PR DESCRIPTION
Hello,

I was wondering if you could add support for tab character as a field delimiter. I've previously hacked this in by changing the DEFAULT_CSV_TAB_DELIMITER define in default_values.h, but since then my win32 build environment has apparently fallen apart.

As whitespace, tab cannot be passed as argument to -d, but I've added an extra argument.

Thanks,
Jacob